### PR TITLE
updating package.json

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "escape-hatch-tooling",
+  "name": "@zircuit-labs/escape-hatch-tooling",
   "version": "1.0.0",
+  "private": true,
   "description": "Tooling for Zircuit escape hatch functionality",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- adding `"name": "@zircuit-labs/escape-hatch-tooling"` which namespaces the package under the `zircuit-labs` org and reduces naming collisions and clarifying ownership
- adding `"private": true` ensures it cannot be accidentally published to the public npm registry